### PR TITLE
Don't remove /dev/null if nginx started from root

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,7 @@ events {
 }
 
 error_log /dev/stderr;
-pid /dev/null;
+pid test-nginx.pid;
 
 daemon off;
 


### PR DESCRIPTION
Nginx deletes pid file on exit. If started from root it can delete
/dev/null too. Create pid file in the current directory instead.